### PR TITLE
Get body only in response

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -209,12 +209,17 @@
                 type = textarea && textarea.getAttribute("data-type") || null,
                 status = textarea && textarea.getAttribute("data-status") || 200,
                 statusText = textarea && textarea.getAttribute("data-statusText") || "OK",
-                content = {
-                  html: root.innerHTML,
-                  text: type ?
-                    textarea.value :
-                    root ? (root.textContent || root.innerText) : null
-                };
+                content = {};
+
+              if (root) {
+                root = root.getElementsByTagName('body')[0] || root;
+              }
+              content = {
+                html: root.innerHTML,
+                text: type ?
+                  textarea.value :
+                  root ? (root.textContent || root.innerText) : null
+              };
               cleanUp();
               completeCallback(status, statusText, content, type ?
                 ("Content-Type: " + type) :


### PR DESCRIPTION
Some browser plugins put scripts in the document's head. We don't want to include that in the response. Only get the <body>